### PR TITLE
Changes in RUC LSM for fractional land/water/sea-ice mask.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,8 +164,8 @@ elseif (${CMAKE_Fortran_COMPILER_ID} STREQUAL "Intel")
     # Force consistent results of math calculations for MG microphysics;
     # in Debug/Bitforbit mode; without this flag, the results of the
     # intrinsic gamma function are different for the non-CCPP and CCPP
-    # version (on Theia with Intel 18). Note this is only required with
-    # dynamic CCPP builds (hybrid, standalone), not with static CCPP builds.
+    # version (on Theia with Intel 18). Note this is only required for
+    # the dynamic CCPP build, not for the static CCPP build.
     if (TRANSITION)
       # Replace -xHost or -xCORE-AVX2 with -xCORE-AVX-I, -no-prec-div with -prec-div, and
       # -no-prec-sqrt with -prec-sqrt for certain files for bit-for-bit reproducibility

--- a/physics/GFS_DCNV_generic.F90
+++ b/physics/GFS_DCNV_generic.F90
@@ -11,6 +11,7 @@
       subroutine GFS_DCNV_generic_pre_finalize()
       end subroutine GFS_DCNV_generic_pre_finalize
 
+#if 0
 !> \brief Interstitial scheme called prior to any deep convective scheme to save state variables for calculating tendencies after the deep convective scheme is executed
 !! \section arg_table_GFS_DCNV_generic_pre_run Argument Table
 !! | local_name      | standard_name                                          | long_name                                                                 | units   | rank | type      |    kind   | intent | optional |
@@ -34,6 +35,7 @@
 !! | errmsg          | ccpp_error_message                                     | error message for error handling in CCPP                                  | none    |    0 | character | len=*     | out    | F        |
 !! | errflg          | ccpp_error_flag                                        | error flag for error handling in CCPP                                     | flag    |    0 | integer   |           | out    | F        |
 !!
+#endif
     subroutine GFS_DCNV_generic_pre_run (im, levs, ldiag3d, cnvgwd, lgocart, do_ca,     &
                                          isppt_deep, gu0, gv0, gt0, gq0_water_vapor,    &
                                          save_u, save_v, save_t, save_qv, ca_deep,      &
@@ -101,6 +103,7 @@
     subroutine GFS_DCNV_generic_post_finalize ()
     end subroutine GFS_DCNV_generic_post_finalize
 
+#if 0
 !> \section arg_table_GFS_DCNV_generic_post_run Argument Table
 !! | local_name      | standard_name                                                                               | long_name                                                            | units         | rank | type              |    kind   | intent | optional |
 !! |-----------------|---------------------------------------------------------------------------------------------|----------------------------------------------------------------------|---------------|------|-------------------|-----------|--------|----------|
@@ -162,6 +165,7 @@
 !! | errmsg          | ccpp_error_message                                                                          | error message for error handling in CCPP                             | none          |    0 | character         | len=*     | out    | F        |
 !! | errflg          | ccpp_error_flag                                                                             | error flag for error handling in CCPP                                | flag          |    0 | integer           |           | out    | F        |
 !!
+#endif
     subroutine GFS_DCNV_generic_post_run (im, levs, lssav, ldiag3d, lgocart, ras, cscnv, do_ca,      &
       isppt_deep, frain, rain1, dtf, cld1d, save_u, save_v, save_t, save_qv, gu0, gv0, gt0,          &
       gq0_water_vapor, ud_mf, dd_mf, dt_mf, con_g, clw_ice, clw_liquid, npdf3d, num_p3d, ncnvcld3d,  &

--- a/physics/GFS_phys_time_vary.scm.F90
+++ b/physics/GFS_phys_time_vary.scm.F90
@@ -3,13 +3,17 @@
 
    module GFS_phys_time_vary
 
-      use ozinterp, only : setindxoz, ozinterpol
+     use ozne_def, only : levozp, oz_coeff, oz_lat, oz_pres, oz_time, ozplin
+     use ozinterp, only : read_o3data, setindxoz, ozinterpol
 
-      use h2ointerp, only : setindxh2o, h2ointerpol
+     use h2o_def,   only : levh2o, h2o_coeff, h2o_lat, h2o_pres, h2o_time, h2oplin
+     use h2ointerp, only : read_h2odata, setindxh2o, h2ointerpol
 
-      use aerclm_def, only : aerin, aer_pres, ntrcaer, ntrcaerm
+     use aerclm_def, only : aerin, aer_pres, ntrcaer, ntrcaerm
+     use aerinterp,  only : read_aerdata, setindxaer, aerinterpol
 
-      use iccn_def,   only : ciplin, ccnin, ci_pres
+     use iccn_def,   only : ciplin, ccnin, ci_pres
+     use iccninterp, only : read_cidata, setindxci, ciinterpol
 
       implicit none
 
@@ -26,61 +30,114 @@
 !! |----------------|--------------------------------------------------------|-------------------------------------------------------------------------|----------|------|-----------------------|-----------|--------|----------|
 !! | Grid           | GFS_grid_type_instance                                 | Fortran DDT containing FV3-GFS grid and interpolation related data      | DDT      |    0 | GFS_grid_type         |           | inout  | F        |
 !! | Model          | GFS_control_type_instance                              | Fortran DDT containing FV3-GFS model control parameters                 | DDT      |    0 | GFS_control_type      |           | in     | F        |
+!! | Interstitial   | GFS_interstitial_type_instance                         | Fortran DDT containing FV3-GFS interstitial data                        | DDT      |    0 | GFS_interstitial_type |           | inout  | F        |
 !! | Tbd            | GFS_tbd_type_instance                                  | Fortran DDT containing FV3-GFS miscellaneous data                       | DDT      |    0 | GFS_tbd_type          |           | in     | F        |
 !! | errmsg         | ccpp_error_message                                     | error message for error handling in CCPP                                | none     |    0 | character             | len=*     | out    | F        |
 !! | errflg         | ccpp_error_flag                                        | error flag for error handling in CCPP                                   | flag     |    0 | integer               |           | out    | F        |
 !!
-      subroutine GFS_phys_time_vary_init (Grid, Model, Tbd, errmsg, errflg)
+      subroutine GFS_phys_time_vary_init (Grid, Model, Interstitial, Tbd, errmsg, errflg)
 
          use GFS_typedefs,          only: GFS_control_type, GFS_grid_type, &
-                                          GFS_Tbd_type
+                                          GFS_Tbd_type, GFS_interstitial_type
 
          implicit none
 
          ! Interface variables
          type(GFS_grid_type),              intent(inout) :: Grid
          type(GFS_control_type),           intent(in)    :: Model
+         type(GFS_interstitial_type),      intent(inout) :: Interstitial
          type(GFS_tbd_type),               intent(in)    :: Tbd
          character(len=*),                 intent(out)   :: errmsg
          integer,                          intent(out)   :: errflg
 
          ! Local variables
-         integer :: i, j, ix, nb
+         integer :: i, j, ix, nb, nt
 
          ! Initialize CCPP error handling variables
          errmsg = ''
          errflg = 0
 
-         nb = 1
+         if (is_initialized) return
 
+         nb = 1
+         nt = 1
+         
+         call read_o3data  (Model%ntoz, Model%me, Model%master)
+
+         ! Consistency check that the hardcoded values for levozp and
+         ! oz_coeff in GFS_typedefs.F90 match what is set by read_o3data
+         ! in GFS_typedefs.F90: allocate (Tbd%ozpl  (IM,levozp,oz_coeff))
+         if (size(Tbd%ozpl, dim=2).ne.levozp) then
+            write(errmsg,'(2a,i0,a,i0)') "Value error in GFS_phys_time_vary_init: ",    &
+                  "levozp from read_o3data does not match value in GFS_typedefs.F90: ", &
+                  levozp, " /= ", size(Tbd%ozpl, dim=2)
+            errflg = 1
+         end if
+         if (size(Tbd%ozpl, dim=3).ne.oz_coeff) then
+            write(errmsg,'(2a,i0,a,i0)') "Value error in GFS_phys_time_vary_init: ",      &
+                  "oz_coeff from read_o3data does not match value in GFS_typedefs.F90: ", &
+                  oz_coeff, " /= ", size(Tbd%ozpl, dim=3)
+            errflg = 1
+         end if
+           
+         call read_h2odata (Model%h2o_phys, Model%me, Model%master)
+         
+         ! Consistency check that the hardcoded values for levh2o and
+         ! h2o_coeff in GFS_typedefs.F90 match what is set by read_o3data
+         ! in GFS_typedefs.F90: allocate (Tbd%h2opl (IM,levh2o,h2o_coeff))
+         if (size(Tbd%h2opl, dim=2).ne.levh2o) then
+            write(errmsg,'(2a,i0,a,i0)') "Value error in GFS_phys_time_vary_init: ",     &
+                  "levh2o from read_h2odata does not match value in GFS_typedefs.F90: ", &
+                  levh2o, " /= ", size(Tbd%h2opl, dim=2)
+            errflg = 1
+         end if
+         if (size(Tbd%h2opl, dim=3).ne.h2o_coeff) then
+            write(errmsg,'(2a,i0,a,i0)') "Value error in GFS_phys_time_vary_init: ",       &
+                  "h2o_coeff from read_h2odata does not match value in GFS_typedefs.F90: ", &
+                  h2o_coeff, " /= ", size(Tbd%h2opl, dim=3)
+            errflg = 1
+         end if 
+                       
          if (Model%aero_in) then
-            ! ! Consistency check that the value for ntrcaerm set in GFS_typedefs.F90
-            ! ! and used to allocate Tbd%aer_nm matches the value defined in aerclm_def
-            ! if (size(Tbd%aer_nm, dim=3).ne.ntrcaerm) then
-            !    write(errmsg,'(2a,i0,a,i0)') "Value error in GFS_phys_time_vary_init: ",     &
-            !          "ntrcaerm from aerclm_def does not match value in GFS_typedefs.F90: ", &
-            !          ntrcaerm, " /= ", size(Tbd%aer_nm, dim=3)
-            !    errflg = 1
-            !    return
-            ! end if
-            ! ! Update the value of ntrcaer in aerclm_def with the value defined
-            ! ! in GFS_typedefs.F90 that is used to allocate the Tbd DDT.
-            ! ! If Model%aero_in is .true., then ntrcaer == ntrcaerm
-            ! ntrcaer = size(Tbd%aer_nm, dim=3)
-            ! ! Read aerosol climatology
-            ! call read_aerdata (Model%me,Model%master,Model%iflip,Model%idate)
+           ! Consistency check that the value for ntrcaerm set in GFS_typedefs.F90
+           ! and used to allocate Tbd%aer_nm matches the value defined in aerclm_def
+           if (size(Tbd%aer_nm, dim=3).ne.ntrcaerm) then
+              write(errmsg,'(2a,i0,a,i0)') "Value error in GFS_phys_time_vary_init: ",     &
+                    "ntrcaerm from aerclm_def does not match value in GFS_typedefs.F90: ", &
+                    ntrcaerm, " /= ", size(Tbd%aer_nm, dim=3)
+              errflg = 1
+           else
+              ! Update the value of ntrcaer in aerclm_def with the value defined
+              ! in GFS_typedefs.F90 that is used to allocate the Tbd DDT.
+              ! If Model%aero_in is .true., then ntrcaer == ntrcaerm
+              ntrcaer = size(Tbd%aer_nm, dim=3)
+              ! Read aerosol climatology
+              call read_aerdata (Model%me,Model%master,Model%iflip,Model%idate)
+           endif
          else
             ! Update the value of ntrcaer in aerclm_def with the value defined
             ! in GFS_typedefs.F90 that is used to allocate the Tbd DDT.
             ! If Model%aero_in is .false., then ntrcaer == 1
             ntrcaer = size(Tbd%aer_nm, dim=3)
          endif
+         
          if (Model%iccn) then
-          !  call read_cidata  ( Model%me, Model%master)
-          !  ! No consistency check needed for in/ccn data, all values are
-          !  ! hardcoded in module iccn_def.F and GFS_typedefs.F90
+            call read_cidata  ( Model%me, Model%master)
+            ! No consistency check needed for in/ccn data, all values are
+            ! hardcoded in module iccn_def.F and GFS_typedefs.F90
          endif
+         
+         ! Update values of oz_pres in Interstitial data type for all threads
+         if (Model%ntoz > 0) then
+            Interstitial%oz_pres = oz_pres
+         end if
 
+         ! Update values of h2o_pres in Interstitial data type for all threads
+         if (Model%h2o_phys) then
+            Interstitial%h2o_pres = h2o_pres
+         end if
+         
+         
          !--- read in and initialize ozone
          if (Model%ntoz > 0) then
             call setindxoz (Model%blksz(nb), Grid%xlat_d, Grid%jindx1_o3, &
@@ -94,19 +151,19 @@
          endif
 
          !--- read in and initialize aerosols
-        !  if (Model%aero_in) then
-        !    call setindxaer (Model%blksz(nb), Grid%xlat_d, Grid%jindx1_aer,           &
-        !                       Grid%jindx2_aer, Grid%ddy_aer, Grid%xlon_d,     &
-        !                       Grid%iindx1_aer, Grid%iindx2_aer, Grid%ddx_aer, &
-        !                       Model%me, Model%master)
-        !  endif
-        !   !--- read in and initialize IN and CCN
-        !  if (Model%iccn) then
-        !      call setindxci (Model%blksz(nb), Grid%xlat_d, Grid%jindx1_ci,       &
-        !                      Grid%jindx2_ci, Grid%ddy_ci, Grid%xlon_d,  &
-        !                      Grid%iindx1_ci, Grid%iindx2_ci, Grid%ddx_ci)
-        !  endif
-
+         if (Model%aero_in) then
+           call setindxaer (Model%blksz(nb), Grid%xlat_d, Grid%jindx1_aer,           &
+                              Grid%jindx2_aer, Grid%ddy_aer, Grid%xlon_d,     &
+                              Grid%iindx1_aer, Grid%iindx2_aer, Grid%ddx_aer, &
+                              Model%me, Model%master)
+         endif
+          !--- read in and initialize IN and CCN
+         if (Model%iccn) then
+             call setindxci (Model%blksz(nb), Grid%xlat_d, Grid%jindx1_ci,       &
+                             Grid%jindx2_ci, Grid%ddy_ci, Grid%xlon_d,  &
+                             Grid%iindx1_ci, Grid%iindx2_ci, Grid%ddx_ci)
+         endif
+         
         !--- initial calculation of maps local ix -> global i and j, store in Tbd
          ix = 0
          nb = 1
@@ -123,17 +180,57 @@
          enddo
 
          is_initialized = .true.
-
-
+         
       end subroutine GFS_phys_time_vary_init
 
-      subroutine GFS_phys_time_vary_finalize()
+!> \section arg_table_GFS_phys_time_vary_finalize Argument Table
+!! | local_name     | standard_name                                          | long_name                                                               | units    | rank |  type                 |   kind    | intent | optional |
+!! |----------------|--------------------------------------------------------|-------------------------------------------------------------------------|----------|------|-----------------------|-----------|--------|----------|
+!! | errmsg         | ccpp_error_message                                     | error message for error handling in CCPP                                | none     |    0 | character             | len=*     | out    | F        |
+!! | errflg         | ccpp_error_flag                                        | error flag for error handling in CCPP                                   | flag     |    0 | integer               |           | out    | F        |
+!!
+      subroutine GFS_phys_time_vary_finalize(errmsg, errflg)
+        implicit none
+
+        ! Interface variables
+        character(len=*),                 intent(out)   :: errmsg
+        integer,                          intent(out)   :: errflg
+
+        ! Initialize CCPP error handling variables
+        errmsg = ''
+        errflg = 0
+
+        if (.not.is_initialized) return
+
+        ! Deallocate ozone arrays
+        if (allocated(oz_lat)  ) deallocate(oz_lat)
+        if (allocated(oz_pres) ) deallocate(oz_pres)
+        if (allocated(oz_time) ) deallocate(oz_time)
+        if (allocated(ozplin)  ) deallocate(ozplin)
+
+        ! Deallocate h2o arrays
+        if (allocated(h2o_lat) ) deallocate(h2o_lat)
+        if (allocated(h2o_pres)) deallocate(h2o_pres)
+        if (allocated(h2o_time)) deallocate(h2o_time)
+        if (allocated(h2oplin) ) deallocate(h2oplin)
+
+        ! Deallocate aerosol arrays
+        if (allocated(aerin)   ) deallocate(aerin)
+        if (allocated(aer_pres)) deallocate(aer_pres)
+
+        ! Deallocate IN and CCN arrays
+        if (allocated(ciplin)  ) deallocate(ciplin)
+        if (allocated(ccnin)   ) deallocate(ccnin)
+        if (allocated(ci_pres) ) deallocate(ci_pres)
+
+        is_initialized = .false.
       end subroutine GFS_phys_time_vary_finalize
 
 !> \section arg_table_GFS_phys_time_vary_run Argument Table
 !! | local_name     | standard_name                                          | long_name                                                               | units         | rank | type                          |    kind   | intent | optional |
 !! |----------------|--------------------------------------------------------|-------------------------------------------------------------------------|---------------|------|-------------------------------|-----------|--------|----------|
 !! | Grid           | GFS_grid_type_instance                                 | Fortran DDT containing FV3-GFS grid and interpolation related data      | DDT           |    0 | GFS_grid_type                 |           | in     | F        |
+!! | Statein        | GFS_statein_type_instance                              | instance of derived type GFS_statein_type                               | DDT           |    0 | GFS_statein_type              |           | in     | F        |
 !! | Model          | GFS_control_type_instance                              | Fortran DDT containing FV3-GFS model control parameters                 | DDT           |    0 | GFS_control_type              |           | inout  | F        |
 !! | Tbd            | GFS_tbd_type_instance                                  | Fortran DDT containing FV3-GFS miscellaneous data                       | DDT           |    0 | GFS_tbd_type                  |           | inout  | F        |
 !! | Sfcprop        | GFS_sfcprop_type_instance                              | Fortran DDT containing FV3-GFS surface fields                           | DDT           |    0 | GFS_sfcprop_type              |           | inout  | F        |
@@ -142,17 +239,19 @@
 !! | errmsg         | ccpp_error_message                                     | error message for error handling in CCPP                                | none          |    0 | character                     | len=*     | out    | F        |
 !! | errflg         | ccpp_error_flag                                        | error flag for error handling in CCPP                                   | flag          |    0 | integer                       |           | out    | F        |
 !!
-      subroutine GFS_phys_time_vary_run (Grid, Model, Tbd, Sfcprop, Cldprop, Diag, errmsg, errflg)
+      subroutine GFS_phys_time_vary_run (Grid, Statein, Model, Tbd, Sfcprop, Cldprop, Diag, errmsg, errflg)
 
         use mersenne_twister,      only: random_setseed, random_number
         use machine,               only: kind_phys
         use GFS_typedefs,          only: GFS_control_type, GFS_grid_type, &
                                          GFS_Tbd_type, GFS_sfcprop_type,  &
-                                         GFS_cldprop_type, GFS_diag_type
+                                         GFS_cldprop_type, GFS_diag_type, &
+                                         GFS_statein_type
 
         implicit none
 
         type(GFS_grid_type),              intent(in)    :: Grid
+        type(GFS_statein_type),           intent(in)    :: Statein
         type(GFS_control_type),           intent(inout) :: Model
         type(GFS_tbd_type),               intent(inout) :: Tbd
         type(GFS_sfcprop_type),           intent(inout) :: Sfcprop
@@ -234,24 +333,24 @@
         endif
 
         !--- aerosol interpolation
-        ! if (Model%aero_in) then
-        !   call aerinterpol (Model%me, Model%master, Model%blksz(nb),             &
-        !                      Model%idate, Model%fhour,                            &
-        !                      Grid%jindx1_aer, Grid%jindx2_aer,  &
-        !                      Grid%ddy_aer,Grid%iindx1_aer,      &
-        !                      Grid%iindx2_aer,Grid%ddx_aer,      &
-        !                      Model%levs,Statein%prsl,                    &
-        !                      Tbd%aer_nm)
-        ! endif
-        !  !--- ICCN interpolation
-        ! if (Model%iccn) then
-        !     call ciinterpol (Model%me, Model%blksz(nb), Model%idate, Model%fhour, &
-        !                      Grid%jindx1_ci, Grid%jindx2_ci,    &
-        !                      Grid%ddy_ci,Grid%iindx1_ci,        &
-        !                      Grid%iindx2_ci,Grid%ddx_ci,        &
-        !                      Model%levs,Statein%prsl,                    &
-        !                      Tbd%in_nm, Tbd%ccn_nm)
-        ! endif
+        if (Model%aero_in) then
+          call aerinterpol (Model%me, Model%master, Model%blksz(nb),             &
+                             Model%idate, Model%fhour,                            &
+                             Grid%jindx1_aer, Grid%jindx2_aer,  &
+                             Grid%ddy_aer,Grid%iindx1_aer,      &
+                             Grid%iindx2_aer,Grid%ddx_aer,      &
+                             Model%levs,Statein%prsl,                    &
+                             Tbd%aer_nm)
+        endif
+         !--- ICCN interpolation
+        if (Model%iccn) then
+            call ciinterpol (Model%me, Model%blksz(nb), Model%idate, Model%fhour, &
+                             Grid%jindx1_ci, Grid%jindx2_ci,    &
+                             Grid%ddy_ci,Grid%iindx1_ci,        &
+                             Grid%iindx2_ci,Grid%ddx_ci,        &
+                             Model%levs,Statein%prsl,                    &
+                             Tbd%in_nm, Tbd%ccn_nm)
+        endif
 
         !--- original FV3 code, not needed for SCM; also not compatible with the way
         !    the time vary steps are run (over each block) --> cannot use

--- a/physics/cs_conv.F90
+++ b/physics/cs_conv.F90
@@ -6,12 +6,12 @@ module cs_conv_pre
 
 !! \section arg_table_cs_conv_pre_init  Argument Table
 !!
-  subroutine cs_conv_pre_init
+  subroutine cs_conv_pre_init()
   end subroutine cs_conv_pre_init
 
 !! \section arg_table_cs_conv_pre_finalize  Argument Table
 !!
-  subroutine cs_conv_pre_finalize
+  subroutine cs_conv_pre_finalize()
   end subroutine cs_conv_pre_finalize
 
 #if 0
@@ -100,12 +100,12 @@ module cs_conv_post
 
 !! \section arg_table_cs_conv_post_init  Argument Table
 !!
-  subroutine cs_conv_post_init
+  subroutine cs_conv_post_init()
   end subroutine cs_conv_post_init
 
 !! \section arg_table_cs_conv_post_finalize  Argument Table
 !!
-  subroutine cs_conv_post_finalize
+  subroutine cs_conv_post_finalize()
   end subroutine cs_conv_post_finalize
 
 !!
@@ -498,6 +498,10 @@ module cs_conv
    real(r8), parameter :: tf=233.16, tcr=263.16, tcrf=1.0/(tcr-tf), tcl=2.0
    logical, save       :: first=.true.
    logical lprnt
+
+   ! Initialize CCPP error handling variables
+   errmsg = ''
+   errflg = 0
 
 !  lprnt = kdt == 1 .and. mype == 38
 !  ipr = 43

--- a/physics/cu_gf_deep.F90
+++ b/physics/cu_gf_deep.F90
@@ -3211,19 +3211,20 @@ endif
         do i=its,itf
          aa0(i)=0.
         enddo
-        do 100 k=kts+1,ktf
-        do 100 i=its,itf
-         if(ierr(i).ne.0)go to 100
-         if(k.lt.kbcon(i))go to 100
-         if(k.gt.ktop(i))go to 100
-         dz=z(i,k)-z(i,k-1)
-         da=zu(i,k)*dz*(9.81/(1004.*( &
-                (t_cup(i,k)))))*dby(i,k-1)/ &
-             (1.+gamma_cup(i,k))
-!         if(k.eq.ktop(i).and.da.le.0.)go to 100
-         aa0(i)=aa0(i)+max(0.,da)
-         if(aa0(i).lt.0.)aa0(i)=0.
-100     continue
+        do k=kts+1,ktf
+          do i=its,itf
+           if(ierr(i).ne.0) exit
+           if(k.lt.kbcon(i)) exit
+           if(k.gt.ktop(i)) exit
+           dz=z(i,k)-z(i,k-1)
+           da=zu(i,k)*dz*(9.81/(1004.*( &
+                  (t_cup(i,k)))))*dby(i,k-1)/ &
+               (1.+gamma_cup(i,k))
+  !         if(k.eq.ktop(i).and.da.le.0.)go to 100
+           aa0(i)=aa0(i)+max(0.,da)
+           if(aa0(i).lt.0.)aa0(i)=0.
+          enddo
+        enddo
 
    end subroutine cup_up_aa0
 
@@ -4356,16 +4357,18 @@ endif
         do i=its,itf
          aa0(i)=0.
         enddo
-        do 100 i=its,itf
-        do 100 k=kts,kbcon(i)
-        if(ierr(i).ne.0 )go to 100
-!        if(k.gt.kbcon(i))go to 100
+        do i=its,itf
+          do k=kts,kbcon(i)
+            if(ierr(i).ne.0 ) exit
+!           if(k.gt.kbcon(i)) exit
 
-          dz = (z_cup (i,k+1)-z_cup (i,k))*g
-          da = dz*(tn(i,k)*(1.+0.608*qo(i,k))-t(i,k)*(1.+0.608*q(i,k)))/dtime
+            dz = (z_cup (i,k+1)-z_cup (i,k))*g
+            da = dz*(tn(i,k)*(1.+0.608*qo(i,k))-t(i,k)*(1.+0.608*q(i,k)))/dtime
 
-         aa0(i)=aa0(i)+da
-100     continue
+            aa0(i)=aa0(i)+da
+          enddo
+        enddo
+             
 
  end subroutine cup_up_aa1bl
 !---------------------------------------------------------------------- 

--- a/physics/cu_gf_driver.F90
+++ b/physics/cu_gf_driver.F90
@@ -33,7 +33,11 @@ contains
          integer,                   intent(in)    :: mpiroot
          character(len=*),          intent(  out) :: errmsg
          integer,                   intent(  out) :: errflg
-
+         
+         ! initialize ccpp error handling variables
+         errmsg = ''
+         errflg = 0
+         
          ! DH* temporary
          if (mpirank==mpiroot) then
             write(0,*) ' -----------------------------------------------------------------------------------------------------------------------------'

--- a/physics/cu_ntiedtke.F90
+++ b/physics/cu_ntiedtke.F90
@@ -119,7 +119,11 @@ contains
          integer,                   intent(in)    :: mpiroot
          character(len=*),          intent(  out) :: errmsg
          integer,                   intent(  out) :: errflg
-
+         
+         ! initialize ccpp error handling variables
+         errmsg = ''
+         errflg = 0
+         
          ! DH* temporary
          if (mpirank==mpiroot) then
             write(0,*) ' -----------------------------------------------------------------------------------------------------------------------------'

--- a/physics/micro_mg3_0.F90
+++ b/physics/micro_mg3_0.F90
@@ -2426,11 +2426,13 @@ subroutine micro_mg_tend (                                       &
         if (do_cldice) then
 
            ! freezing of rain to produce ice if mean rain size is smaller than Dcs
-           if (lamr(i,k) > qsmall .and. one/lamr(i,k) < Dcs) then
-              mnuccri(i,k) = mnuccr(i,k)
-              nnuccri(i,k) = nnuccr(i,k)
-              mnuccr(i,k)  = zero 
-              nnuccr(i,k)  = zero
+           if (lamr(i,k) > qsmall) then
+             if(one/lamr(i,k) < Dcs) then
+                mnuccri(i,k) = mnuccr(i,k)
+                nnuccri(i,k) = nnuccr(i,k)
+                mnuccr(i,k)  = zero 
+                nnuccr(i,k)  = zero
+             end if
            end if
         end if
 
@@ -2977,7 +2979,7 @@ subroutine micro_mg_tend (                                       &
 !               (nnucct(i,k)+tmpfrz+nnudep(i,k)+nsacwi(i,k))*lcldm(i,k)+(nsubi(i,k)-nprci(i,k)- &
 !               nprai(i,k))*icldm(i,k)+nnuccri(i,k)*precip_frac(i,k)
 
-          nitend(i,k) = nitend(i,k) + nnuccd(i,k) +                                   &
+          nitend(i,k) = nitend(i,k) + nnuccd(i,k)                                     &
                +  (nnucct(i,k)+tmpfrz+nnudep(i,k)+nsacwi(i,k)+nmultg(i,k))*lcldm(i,k) &
                + (nsubi(i,k)-nprci(i,k)-nprai(i,k))*icldm(i,k)                        &
                + (nnuccri(i,k)+nmultrg(i,k))*precip_frac(i,k)

--- a/physics/module_gfdl_cloud_microphys.F90
+++ b/physics/module_gfdl_cloud_microphys.F90
@@ -684,7 +684,16 @@ subroutine mpdrv (hydrostatic, uin, vin, w, delp, pt, qv, ql, qr, qi, qs,     &
     ! -----------------------------------------------------------------------
     ! use local variables
     ! -----------------------------------------------------------------------
-
+    
+    !GJF: assign values to intent(out) variables that are commented out
+    w_var = 0.0
+    vt_r = 0.0
+    vt_s = 0.0
+    vt_g = 0.0
+    vt_i = 0.0
+    qn2 = 0.0
+    !GJF
+    
     do i = is, ie
 
         do k = ktop, kbot

--- a/physics/module_mp_thompson.F90
+++ b/physics/module_mp_thompson.F90
@@ -50,7 +50,7 @@ MODULE module_mp_thompson
 
       USE module_mp_radar
 
-#ifndef SION
+#if !defined(SION) && defined(MPI)
       use mpi
 #endif
 

--- a/physics/module_sf_ruclsm.F90
+++ b/physics/module_sf_ruclsm.F90
@@ -5859,7 +5859,7 @@ print *, 'D9SN,SOILT,TSOB : ', D9SN,SOILT,TSOB
         COSMC(1)=0.
         RHSMC(1)=SOILMOIS(NZS)
 !
-        DO 330 K=1,NZS2
+        DO K=1,NZS2
           KN=NZS-K
           K1=2*KN-3
           X4=2.*DTDZS(K1)*DIFFU(KN-1)
@@ -5872,10 +5872,11 @@ print *, 'D9SN,SOILT,TSOB : ', D9SN,SOILT,TSOB
           print *,'q2,soilmois(kn),DIFFU(KN),x2,HYDRO(KN+1),DTDZS2(KN-1),kn,k' &
                   ,q2,soilmois(kn),DIFFU(KN),x2,HYDRO(KN+1),DTDZS2(KN-1),kn,k
     ENDIF
- 330      RHSMC(K+1)=(SOILMOIS(KN)+Q2*RHSMC(K)                            &
+          RHSMC(K+1)=(SOILMOIS(KN)+Q2*RHSMC(K)                            &
                    +TRANSP(KN)                                            &
                    /(ZSHALF(KN+1)-ZSHALF(KN))                             &
                    *DELT)/DENOM
+        ENDDO
 
 ! --- MOISTURE BALANCE BEGINS HERE
 

--- a/physics/mp_thompson_post.F90
+++ b/physics/mp_thompson_post.F90
@@ -185,7 +185,11 @@ contains
       ! CCPP error handling
       character(len=*),          intent(  out) :: errmsg
       integer,                   intent(  out) :: errflg
-
+      
+      ! initialize ccpp error handling variables
+      errmsg = ''
+      errflg = 0
+      
       ! Check initialization state
       if (.not. is_initialized) return
 

--- a/physics/satmedmfvdif.F
+++ b/physics/satmedmfvdif.F
@@ -139,7 +139,7 @@
      &                     dtsfc(im),     dqsfc(im),
      &                     hpbl(im) 
 !
-      logical, intent(out)  :: dspheat
+      logical, intent(in)  :: dspheat
       character(len=*), intent(out) :: errmsg
       integer,          intent(out) :: errflg
 

--- a/physics/sfc_drv_ruc.F90
+++ b/physics/sfc_drv_ruc.F90
@@ -160,6 +160,7 @@ module lsm_ruc
 !! | con_rv          | gas_constant_water_vapor                                                     | ideal gas constant for water vapor                              | J kg-1 K-1    |    0 | real      | kind_phys | in     | F        |
 !! | con_hvap        | latent_heat_of_vaporization_of_water_at_0C                                   | latent heat of vaporization/sublimation (hvap)                  | J kg-1        |    0 | real      | kind_phys | in     | F        |
 !! | con_fvirt       | ratio_of_vapor_to_dry_air_gas_constants_minus_one                            | rv/rd - 1 (rv = ideal gas constant for water vapor)             | none          |    0 | real      | kind_phys | in     | F        |
+!! | land            | flag_nonzero_land_surface_fraction                                           | flag indicating presence of some land surface area fraction     | flag          |    1 | logical   |           | in     | F        |
 !! | rainnc          | lwe_thickness_of_explicit_rainfall_amount_from_previous_timestep             | explicit rainfall from previous timestep                        | m             |    1 | real      | kind_phys | in     | F        |
 !! | rainc           | lwe_thickness_of_convective_precipitation_amount_from_previous_timestep      | convective_precipitation_amount from previous timestep          | m             |    1 | real      | kind_phys | in     | F        |
 !! | ice             | lwe_thickness_of_ice_amount_from_previous_timestep                           | ice amount from previous timestep                               | m             |    1 | real      | kind_phys | in     | F        |
@@ -167,8 +168,8 @@ module lsm_ruc
 !! | graupel         | lwe_thickness_of_graupel_amount_from_previous_timestep                       | graupel amount from previous timestep                           | m             |    1 | real      | kind_phys | in     | F        |
 !! | srflag          | flag_for_precipitation_type                                                  | snow/rain flag for precipitation                                | flag          |    1 | real      | kind_phys | in     | F        |
 !! | sncovr1         | surface_snow_area_fraction_over_land                                         | surface snow area fraction                                      | frac          |    1 | real      | kind_phys | inout  | F        |
-!! | weasd           | water_equivalent_accumulated_snow_depth                                      | water equiv of acc snow depth over land and sea ice             | mm            |    1 | real      | kind_phys | inout  | F        |
-!! | snwdph          | surface_snow_thickness_water_equivalent                                      | water equivalent snow depth over land                           | mm            |    1 | real      | kind_phys | inout  | F        |
+!! | weasd           | water_equivalent_accumulated_snow_depth_over_land                            | water equiv of acc snow depth over land                         | mm            |    1 | real      | kind_phys | inout  | F        |
+!! | snwdph          | surface_snow_thickness_water_equivalent_over_land                            | water equivalent snow depth over land                           | mm            |    1 | real      | kind_phys | inout  | F        |
 !! | sr              | ratio_of_snowfall_to_rainfall                                                | snow ratio: ratio of snow to total precipitation                | frac          |    1 | real      | kind_phys | in     | F        |
 !! | rhosnf          | density_of_frozen_precipitation                                              | density of frozen precipitation                                 | kg m-3        |    1 | real      | kind_phys | out    | F        |
 !! | zf              | height_above_ground_at_lowest_model_layer                                    | layer 1 height above ground (not MSL)                           | m             |    1 | real      | kind_phys | in     | F        |
@@ -186,8 +187,8 @@ module lsm_ruc
 !! | wspd            | wind_speed_at_lowest_model_layer                                             | wind speed at lowest model level                                | m s-1         |    1 | real      | kind_phys | inout  | F        |
 !! | cm              | surface_drag_coefficient_for_momentum_in_air                                 | surface exchange coeff for momentum                             | none          |    1 | real      | kind_phys | in     | F        |
 !! | ch              | surface_drag_coefficient_for_heat_and_moisture_in_air                        | surface exchange coeff heat & moisture                          | none          |    1 | real      | kind_phys | in     | F        |
-!! | chh             | surface_drag_mass_flux_for_heat_and_moisture_in_air                          | surf h&m exch coef time surf wind & density                     | kg m-2 s-1    |    1 | real      | kind_phys | inout  | F        |
-!! | cmm             | surface_drag_wind_speed_for_momentum_in_air                                  | surf mom exch coef time mean surf wind                          | m s-1         |    1 | real      | kind_phys | inout  | F        |
+!! | chh             | surface_drag_mass_flux_for_heat_and_moisture_in_air_over_land                | thermal exchange coefficient over land                          | kg m-2 s-1    |    1 | real      | kind_phys | inout  | F        |
+!! | cmm             | surface_drag_wind_speed_for_momentum_in_air_over_land                        | momentum exchange coefficient over land                         | m s-1         |    1 | real      | kind_phys | inout  | F        |
 !! | wet1            | normalized_soil_wetness                                                      | normalized soil wetness                                         | frac          |    1 | real      | kind_phys | inout  | F        |
 !! | canopy          | canopy_water_amount                                                          | canopy water amount                                             | kg m-2        |    1 | real      | kind_phys | inout  | F        |
 !! | sigmaf          | vegetation_area_fraction                                                     | areal fractional cover of green vegetation                      | frac          |    1 | real      | kind_phys | in     | F        |
@@ -195,8 +196,8 @@ module lsm_ruc
 !! | alvwf           | mean_vis_albedo_with_weak_cosz_dependency                                    | mean vis albedo with weak cosz dependency                       | frac          |    1 | real      | kind_phys | in     | F        |
 !! | alnwf           | mean_nir_albedo_with_weak_cosz_dependency                                    | mean nir albedo with weak cosz dependency                       | frac          |    1 | real      | kind_phys | in     | F        |
 !! | snoalb          | upper_bound_on_max_albedo_over_deep_snow                                     | maximum snow albedo                                             | frac          |    1 | real      | kind_phys | in     | F        |
-!! | zorl            | surface_roughness_length                                                     | surface roughness length                                        | cm            |    1 | real      | kind_phys | inout  | F        |
-!! | qsurf           | surface_specific_humidity                                                    | surface air saturation specific humidity                        | kg kg-1       |    1 | real      | kind_phys | inout  | F        |
+!! | zorl            | surface_roughness_length_over_land_interstitial                              | surface roughness length over land  (temporary use as interstitial)| cm         |    1 | real      | kind_phys | inout  | F        |
+!! | qsurf           | surface_specific_humidity_over_land                                          | surface air saturation specific humidity over land              | kg kg-1       |    1 | real      | kind_phys | inout  | F        |
 !! | sfcqc           | cloud_condensed_water_mixing_ratio_at_surface                                | moist cloud water mixing ratio at surface                       | kg kg-1       |    1 | real      | kind_phys | inout  | F        |
 !! | sfcqv           | water_vapor_mixing_ratio_at_surface                                          | water vapor mixing ratio at surface                             | kg kg-1       |    1 | real      | kind_phys | inout  | F        |
 !! | sfcdew          | surface_condensation_mass                                                    | surface condensation mass                                       | kg m-2        |    1 | real      | kind_phys | inout  | F        |
@@ -217,14 +218,14 @@ module lsm_ruc
 !! | smfrkeep        | volume_fraction_of_frozen_soil_moisture_for_land_surface_model               | volume fraction of frozen soil moisture for lsm                 | frac          |    2 | real      | kind_phys | inout  | F        |
 !! | tslb            | soil_temperature_for_land_surface_model                                      | soil temperature for land surface model                         | K             |    2 | real      | kind_phys | inout  | F        |
 !! | stm             | soil_moisture_content                                                        | soil moisture content                                           | kg m-2        |    1 | real      | kind_phys | inout  | F        |
-!! | tskin           | surface_skin_temperature                                                     | surface skin temperature                                        | K             |    1 | real      | kind_phys | inout  | F        |
-!! | tsurf           | surface_skin_temperature_after_iteration                                     | surface skin temperature after iteration                        | K             |    1 | real      | kind_phys | inout  | F        |
+!! | tskin           | surface_skin_temperature_over_land_interstitial                              | surface skin temperature over land  (temporary use as interstitial)| K          |    1 | real      | kind_phys | inout  | F        |
+!! | tsurf           | surface_skin_temperature_after_iteration_over_land                           | surface skin temperature after iteration over land              | K             |    1 | real      | kind_phys | inout  | F        |
 !! | tice            | sea_ice_temperature                                                          | sea ice surface skin temperature                                | K             |    1 | real      | kind_phys | inout  | F        |
 !! | tsnow           | snow_temperature_bottom_first_layer                                          | snow temperature at the bottom of first snow layer              | K             |    1 | real      | kind_phys | inout  | F        |
 !! | snowfallac      | total_accumulated_snowfall                                                   | run-total snow accumulation on the ground                       | kg m-2        |    1 | real      | kind_phys | inout  | F        |
 !! | acsnow          | accumulated_water_equivalent_of_frozen_precip                                | snow water equivalent of run-total frozen precip                | kg m-2        |    1 | real      | kind_phys | inout  | F        |
-!! | evap            | kinematic_surface_upward_latent_heat_flux                                    | kinematic surface upward evaporation flux                       | kg kg-1 m s-1 |    1 | real      | kind_phys | out    | F        |
-!! | hflx            | kinematic_surface_upward_sensible_heat_flux                                  | kinematic surface upward sensible heat flux                     | K m s-1       |    1 | real      | kind_phys | out    | F        |
+!! | evap            | kinematic_surface_upward_latent_heat_flux_over_land                          | kinematic surface upward evaporation flux over land             | kg kg-1 m s-1 |    1 | real      | kind_phys | out    | F        |
+!! | hflx            | kinematic_surface_upward_sensible_heat_flux_over_land                        | kinematic surface upward sensible heat flux over land           | K m s-1       |    1 | real      | kind_phys | out    | F        |
 !! | evbs            | soil_upward_latent_heat_flux                                                 | soil upward latent heat flux                                    | W m-2         |    1 | real      | kind_phys | out    | F        |
 !! | evcw            | canopy_upward_latent_heat_flux                                               | canopy upward latent heat flux                                  | W m-2         |    1 | real      | kind_phys | out    | F        |
 !! | sbsno           | snow_deposition_sublimation_upward_latent_heat_flux                          | latent heat flux from snow depo/subl                            | W m-2         |    1 | real      | kind_phys | out    | F        |
@@ -233,7 +234,7 @@ module lsm_ruc
 !! | drain           | subsurface_runoff_flux                                                       | subsurface runoff flux                                          | g m-2 s-1     |    1 | real      | kind_phys | out    | F        |
 !! | runoff          | total_runoff                                                                 | total water runoff                                              | kg m-2        |    1 | real      | kind_phys | inout  | F        |
 !! | srunoff         | surface_runoff                                                               | surface water runoff (from lsm)                                 | kg m-2        |    1 | real      | kind_phys | inout  | F        |
-!! | gflux           | upward_heat_flux_in_soil                                                     | soil heat flux                                                  | W m-2         |    1 | real      | kind_phys | out    | F        |
+!! | gflux           | upward_heat_flux_in_soil_over_land                                           | soil heat flux over land                                        | W m-2         |    1 | real      | kind_phys | out    | F        |
 !! | shdmin          | minimum_vegetation_area_fraction                                             | min fractional coverage of green vegetation                     | frac          |    1 | real      | kind_phys | in     | F        |
 !! | shdmax          | maximum_vegetation_area_fraction                                             | max fractional coverage of green vegetation                     | frac          |    1 | real      | kind_phys | in     | F        |
 !! | flag_iter       | flag_for_iteration                                                           | flag for iteration                                              | flag          |    1 | logical   |           | in     | F        |
@@ -252,7 +253,7 @@ module lsm_ruc
      &       sfcemis, dlwflx, dswsfc, snet, delt, tg3, cm, ch,          &
      &       prsl1, zf, islmsk, ddvel, shdmin, shdmax, alvwf, alnwf,    &
      &       snoalb, sfalb, flag_iter, flag_guess, isot, ivegsrc, fice, &
-     &       smc, stc, slc, lsm_ruc, lsm,                               &
+     &       smc, stc, slc, lsm_ruc, lsm, land,                         &
      &       smcwlt2, smcref2, wspd, do_mynnsfclay,                     &
 ! --- constants
      &       con_cp, con_rv, con_rd, con_g, con_pi, con_hvap, con_fvirt,&
@@ -299,7 +300,7 @@ module lsm_ruc
                                             con_pi, con_rd,             &
                                             con_hvap, con_fvirt
 
-      logical, dimension(im), intent(in) :: flag_iter, flag_guess
+      logical, dimension(im), intent(in) :: flag_iter, flag_guess, land
       logical,                intent(in) :: do_mynnsfclay
 
 !  ---  in/out:
@@ -431,14 +432,14 @@ module lsm_ruc
                                zs, sh2o, smfrkeep, tslb, smois, wet1,    & ! out
                                errmsg, errflg)
 
-        do i  = 1, im ! n - horizontal loop
+        !do i  = 1, im ! n - horizontal loop
           ! overwrite Noah soil fields with initialized RUC soil fields for output
-          do k = 1, lsoil
-            smc(i,k)   = smois(i,k)
-            slc(i,k)   = sh2o(i,k)
-            stc(i,k)   = tslb(i,k)
-          enddo
-        enddo ! i
+          !do k = 1, lsoil
+          !  smc(i,k)   = smois(i,k)
+          !  slc(i,k)   = sh2o(i,k)
+          !  stc(i,k)   = tslb(i,k)
+          !enddo
+        !enddo ! i
 
       endif ! flag_init=.true.,iter=1
 !-- end of initialization
@@ -489,7 +490,7 @@ module lsm_ruc
 
       do i  = 1, im ! i - horizontal loop
         ! reassign smcref2 and smcwlt2 to RUC values
-        if(islmsk(i) == 0 .or. islmsk(i) == 2) then
+        if(.not. land(i)) then
           !water and sea ice
           smcref2 (i) = 1.
           smcwlt2 (i) = 0.
@@ -502,7 +503,8 @@ module lsm_ruc
 
       do i  = 1, im ! i - horizontal loop
         !> - Set flag for land and ice points.
-        flag(i) = (islmsk(i) == 1 .or. islmsk(i) == 2)
+        !- 10may19 - ice points are turned off.
+        flag(i) = land(i)
       enddo
 
       do i  = 1, im ! i - horizontal loop
@@ -700,6 +702,13 @@ module lsm_ruc
         if(ivegsrc == 1) then   ! IGBP - MODIS
         !> - Prepare land/ice/water masks for RUC LSM
         !SLMSK0   - SEA(0),LAND(1),ICE(2) MASK
+         IF (LAND(I)) then 
+         ! when LAND fraction is .true.
+            vtype(i,j) = vegtype(i)
+            stype(i,j) = soiltyp(i)
+            xland(i,j) = 1.
+            xice(i,j)  = 0.
+         ELSE
           if(islmsk(i) == 0.) then
             vtype(i,j) = 17 ! 17 - water (oceans and lakes) in MODIS
             stype(i,j) = 14
@@ -720,6 +729,7 @@ module lsm_ruc
             xland(i,j) = 1.
             xice(i,j) = fice(i)  ! fraction of sea-ice
           endif
+         ENDIF ! land=.true.
         else
           print *,'MODIS landuse is not available'
         endif
@@ -1068,11 +1078,11 @@ module lsm_ruc
           smfrkeep(i,k) = smfrsoil(i,k,j)
         enddo
 
-        do k = 1, lsoil
-          smc(i,k)   = smsoil(i,k,j)
-          slc(i,k)   = slsoil(i,k,j)
-          stc(i,k)   = stsoil(i,k,j)
-        enddo
+        !do k = 1, lsoil
+        !  smc(i,k)   = smsoil(i,k,j)
+        !  slc(i,k)   = slsoil(i,k,j)
+        !  stc(i,k)   = stsoil(i,k,j)
+        !enddo
 
 !  --- ...  do not return the following output fields to parent model
 !    ec      - canopy water evaporation (m s-1)

--- a/physics/sfcsub.F
+++ b/physics/sfcsub.F
@@ -2697,7 +2697,7 @@
       real (kind=kind_io8), allocatable :: data8(:)
       real (kind=kind_io4), allocatable :: data4(:)
 !
-      logical, allocatable :: lbms(:)
+      logical*1, allocatable :: lbms(:)
 !
       integer kpds(200),kgds(200)
       integer jpds(200),jgds(200), kpds0(200)
@@ -8150,7 +8150,7 @@ cjfe
       real (kind=kind_io8), allocatable :: rlngrb(:), rltgrb(:)
 !
       logical lmask, yr2kc, gaus, ijordr
-      logical, allocatable :: lbms(:)
+      logical*1, allocatable :: lbms(:)
 !
       integer, intent(in) :: kpds7
       integer kpds(1000),kgds(1000)


### PR DESCRIPTION
For this initial implementation of fractional land mask, RUC LSM will be called
only for land points. Sea ice points will be covered with the call to sfc_sice.
Also, this commit removes sending top 4 levels of RUC soil variables to the 4-layer Noah variables.
This was done on the early stages of RUC LSM implementation to see RUC soil variables in the model output.